### PR TITLE
Convert REFERENCES from YAML to Markdown

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,7 @@
+# References
+
+References for README cards / icons
+
+- [github-readme-stats](https://github.com/anuraghazra/github-readme-stats)
+- [skill-icons](https://github.com/tandpfun/skill-icons)
+- [profile-view-counter](https://github.com/antonkomarev/github-profile-views-counter)

--- a/REFERENCES.yml
+++ b/REFERENCES.yml
@@ -1,6 +1,0 @@
-#
-# References for README cards / icons
-#
-github-readme-stats: https://github.com/anuraghazra/github-readme-stats
-skill-icons: https://github.com/tandpfun/skill-icons
-profile-view-counter: https://github.com/antonkomarev/github-profile-views-counter


### PR DESCRIPTION
Replace REFERENCES.yml with REFERENCES.md for better readability.
Links are now formatted as Markdown list items.

https://claude.ai/code/session_013EoHM5bhi5iMA9Hao6va2u